### PR TITLE
URL Cleanup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 vFabric Administration Server Python API
 ========================================
-The vFabric Administration Server (VAS) API is a Python library used for interacting with the `vFabric Administration Server <http://www.vmware.com/support/pubs/vfabric-vas.html>`_.
+The vFabric Administration Server (VAS) API is a Python library used for interacting with the `vFabric Administration Server <https://www.vmware.com/support/pubs/vfabric-vas.html>`_.
 
 VAS's primary mode of interaction is via RESTful interface.  This API enables the use of VAS using rich Python types, eliminating the need for a detailed understanding of the REST API and its JSON payloads.
 
@@ -12,7 +12,7 @@ The VAS Python API requires Python 2.7.  It has been built and tested on 2.7.3.
 
 Installation
 ------------
-The VAS Python egg is available on `PyPI <http://pypi.python.org/pypi/vas>`_.  To install it run::
+The VAS Python egg is available on `PyPI <https://pypi.python.org/pypi/vas>`_.  To install it run::
 
     pip install vas
 
@@ -42,7 +42,7 @@ VAS
 
 Documentation
 ~~~~~~~~~~~~~
-You may also like to look at the `API Documentation <http://packages.python.org/vas>`_.
+You may also like to look at the `API Documentation <https://packages.python.org/vas>`_.
 
 
 License

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -248,4 +248,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'https://docs.python.org/': None}

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup, find_packages
 setup(
     name='vas',
     version='1.1.0.dev',
-    url='http://vfabric.co',
+    url='https://www.vmware.com/vfabric',
     author='VMware',
     author_email='support@vmware.com',
     description='vFabric Administration Server Python API',

--- a/vas/shared/Security.py
+++ b/vas/shared/Security.py
@@ -65,7 +65,7 @@ class Security(object):
         command.
 
         .. |chown| replace:: ``chown``
-        .. _chown: http://en.wikipedia.org/wiki/Chown
+        .. _chown: https://en.wikipedia.org/wiki/Chown
 
         :param str  owner:  The new owner of the item or collection.  Unchanged if :obj:`None`.
         :param str  group:  The new group of the item or collection.  Unchanged if :obj:`None`.
@@ -86,7 +86,7 @@ class Security(object):
         """Change the permissions for an item or collection. Analogous to the UNIX |chmod|_ command.
 
         .. |chmod| replace:: ``chmod``
-        .. _chmod: http://en.wikipedia.org/wiki/Chmod
+        .. _chmod: https://en.wikipedia.org/wiki/Chmod
 
         :param list owner:  The new owner class permissions of the item or collection. Legal values are any of ``READ``,
                             ``WRITE``, and ``EXECUTE``. Unchanged if :obj:`None`.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://en.wikipedia.org/wiki/Chmod with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Chmod ([https](https://en.wikipedia.org/wiki/Chmod) result 200).
* http://en.wikipedia.org/wiki/Chown with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Chown ([https](https://en.wikipedia.org/wiki/Chown) result 200).
* http://www.vmware.com/support/pubs/vfabric-vas.html with 1 occurrences migrated to:  
  https://www.vmware.com/support/pubs/vfabric-vas.html ([https](https://www.vmware.com/support/pubs/vfabric-vas.html) result 200).
* http://packages.python.org/vas with 1 occurrences migrated to:  
  https://packages.python.org/vas ([https](https://packages.python.org/vas) result 301).
* http://pypi.python.org/pypi/vas with 1 occurrences migrated to:  
  https://pypi.python.org/pypi/vas ([https](https://pypi.python.org/pypi/vas) result 301).
* http://vfabric.co (301) with 1 occurrences migrated to:  
  https://www.vmware.com/vfabric ([https](https://vfabric.co) result 301).
* http://docs.python.org/ with 1 occurrences migrated to:  
  https://docs.python.org/ ([https](https://docs.python.org/) result 302).